### PR TITLE
Update vpg.py

### DIFF
--- a/spinup/algos/pytorch/vpg/vpg.py
+++ b/spinup/algos/pytorch/vpg/vpg.py
@@ -292,7 +292,7 @@ def vpg(env_fn, actor_critic=core.MLPActorCritic, ac_kwargs=dict(),  seed=0,
                 if epoch_ended and not(terminal):
                     print('Warning: trajectory cut off by epoch at %d steps.'%ep_len, flush=True)
                 # if trajectory didn't reach terminal state, bootstrap value target
-                if timeout or epoch_ended:
+                if (timeout or epoch_ended) and not d:
                     _, v, _ = ac.step(torch.as_tensor(o, dtype=torch.float32))
                 else:
                     v = 0


### PR DESCRIPTION
The modification is in line 295. The original one is 
if timeout or epoch_ended:
However, it does not consider the situation that the game falls in the max_ep_len step. Therefore, the value of the final state s will be assigned with a non-zero scalar. We should classify this situation into the else branch. So change the code to
if (timeout or epoch_ended) and not d:
to ensure that the episode is interrupted AND the current state is not the final state.